### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled command line

### DIFF
--- a/jes.py
+++ b/jes.py
@@ -2,6 +2,7 @@
 from flask import Flask, request, render_template_string
 import sqlite3
 import os
+import subprocess
  
 app = Flask(__name__)
  
@@ -26,9 +27,11 @@ def search():
  
 @app.route("/rce")
 def rce():
-    # --- Vulnerable: Remote Code Execution ---
-    cmd = request.args.get("cmd")
-    output = os.popen(cmd).read()  # ❌ executes arbitrary commands
+    # --- Mitigated: Uses allowlist to prevent arbitrary code execution ---
+    cmd_key = request.args.get("cmd")
+    if cmd_key not in ALLOWED_COMMANDS:
+        return "<pre>Invalid command</pre>", 400
+    output = subprocess.run(ALLOWED_COMMANDS[cmd_key], capture_output=True, text=True).stdout
     return f"<pre>{output}</pre>"
  
 @app.route("/xss")


### PR DESCRIPTION
Potential fix for [https://github.com/jeslinpaulj-source/samplerepo_autofix/security/code-scanning/5](https://github.com/jeslinpaulj-source/samplerepo_autofix/security/code-scanning/5)

The best way to fix this vulnerability is to avoid invoking shell commands with arbitrary user input. Instead, restrict the user input to a set of predefined, safe commands via an allowlist.  
- Define a dictionary or list of allowed commands on the server.
- Accept only specific command names as user input.
- Look up the command in the allowlist and execute it (if necessary) without using the shell.
- Use `subprocess.run` with `shell=False` rather than `os.popen`, and pass arguments as lists.
- Update the `/rce` endpoint accordingly.

**Changes needed:**
- Add an allowlist: e.g., `ALLOWED_COMMANDS = {"date": ["date"], "uptime": ["uptime"]}` at the top.
- In `/rce`, get the desired command key, check if it's in the allowlist.
- Execute only allowlisted commands, never passing user input directly to `os.popen` or any shell command.
- Replace `os.popen(cmd)` with e.g. `subprocess.run(...)` for additional safety.
- Import `subprocess` at the top if not already.

All changes are in `jes.py`, as shown.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
